### PR TITLE
more powerful Global service

### DIFF
--- a/public/services/global.js
+++ b/public/services/global.js
@@ -1,19 +1,118 @@
 'use strict';
+angular.module('mean.system')
+  .factory('Global', ['$q', '$http', '$timeout',
+  function($q, $http, $timeout) {
+    var _identity = undefined,
+      _authenticated = false,
+      _globals = undefined;
 
-//Global service for global variables
-angular.module('mean.system').factory('Global', [
-
-  function() {
-    var _this = this;
-    _this._data = {
-      user: window.user,
-      authenticated: false,
-      isAdmin: false
-    };
-    if (window.user && window.user.roles) {
-      _this._data.authenticated = window.user.roles.length;
-      _this._data.isAdmin = window.user.roles.indexOf('admin') !== -1;
+    function makeGlobals(userObj) {
+      var globals = { authenticated: 0, isAdmin: false, user: {}};
+      if (userObj && userObj.roles) {
+        globals.authenticated = userObj.roles.length;
+        globals.isAdmin = userObj.roles.indexOf('admin') !== -1;
+        globals.user = userObj;
+      }
+      return globals;
     }
-    return _this._data;
+
+    return {
+      isIdentityResolved: function() {
+        return angular.isDefined(_identity);
+      },
+      globals: function(force) {
+        var deferred = $q.defer();
+
+        if (force === true) _globals = undefined;
+
+        // check if we have globals already, reuse it by immediately resolving
+        if (angular.isDefined(_globals)) {
+          deferred.resolve(_globals);
+          return deferred.promise;
+        } else if (angular.isDefined(_identity)) {
+          deferred.resolve(makeGlobals(_identity));
+          return deferred.promise;
+        }
+
+        // attempt to read the new identity from localStorage
+        // timeout to illustrate deferred resolution
+        $timeout(function() {
+          _globals = angular.fromJson(localStorage.getItem('globals'));
+          deferred.resolve(_globals);
+        }, 1000);
+
+        return deferred.promise;
+      },
+      isAuthenticated: function() {
+        return _authenticated;
+      },
+      isAdmin: function() {
+        if (!_authenticated || !_identity.roles) return false;
+        return _identity.roles.indexOf('admin') > -1;
+      },
+      isInRole: function(role) {
+        if (!_authenticated || !_identity.roles) return false;
+        return _identity.roles.indexOf(role) > -1;
+      },
+      isInAnyRole: function(roles) {
+        if (!_authenticated || !_identity.roles) return false;
+
+        for (var i = 0; i < roles.length; i++) {
+          if (this.isInRole(roles[i])) return true;
+        }
+
+        return false;
+      },
+      authenticate: function(identity) {
+        _identity = identity;
+        _authenticated = identity != null;
+        _globals = makeGlobals(identity);
+
+        // we'll store the identity in localStorage for future
+        if (identity) {
+          localStorage.setItem('identity', angular.toJson(identity));
+          localStorage.setItem('globals', angular.toJson(_globals));
+        } else {
+          localStorage.removeItem('identity');
+          localStorage.removeItem('globals');
+        }
+      },
+      identity: function(force) {
+        var deferred = $q.defer();
+
+        if (force === true) _identity = undefined;
+
+        // check and see if we have retrieved the identity data from the server. if we have, reuse it by immediately resolving
+        if (angular.isDefined(_identity)) {
+          deferred.resolve(_identity);
+
+          return deferred.promise;
+        }
+
+        // otherwise, retrieve the identity data from the server, update the identity object, and then resolve.
+        $http.get('/api/users/me')
+          .success(function(data) {
+            _identity = data;
+            _authenticated = true;
+            deferred.resolve(_identity);
+          })
+          .error(function () {
+            _identity = null;
+            _authenticated = false;
+            deferred.resolve(_identity);
+          });
+
+        // attempt to read the identity from localStorage
+        // timeout to illustrate deferred resolution
+        // var self = this;
+        // $timeout(function() {
+        //   _identity = angular.fromJson(localStorage.getItem('globals'));
+        //   self.authenticate(_identity);
+        //   deferred.resolve(_identity);
+        // }, 1000);
+
+        return deferred.promise;
+      }
+    };
   }
 ]);


### PR DESCRIPTION
On successful auth, the MeanUser service now calls `Global.authenticate(userObj);` to cache the authenticated user, and on logout the service is cleared. I tried to keep the spirit of the old module but add convenience methods like `isInAnyRole([])` `isAdmin()` etc.

I have not yet changed any of the mean-cli scaffold or any package using `Global`, but didn't really see anywhere the service was consumed other than slapping it on the scope.
## Usage:
### In controller:

To use the convenience methods, just set Global to your
`$scope.global = Global;`
### In view:

`ng-if="global.isAdmin()"`
`ng-if="global.isAuthenticated()"`
`ng-if="global.isInRole('admin')"`
`ng-if="global.isInAnyRole(['admin, 'superadmin'])"`
### Backwards compatibility

`Global.globals()` returns the same info as the old service, but now returns a promise. If all you need is the old Global object, so you could do something like:

```
Global.globals().then(function(globals) {
  // vm.globals = globals;
  $scope.globals = globals; // depending on your controller syntax
});
```

`$scope.globals = { user: {}, authenticated: false, isAdmin: false}`
## Fixes:

https://github.com/linnovate/mean/issues/1056
